### PR TITLE
chore: release v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1](https://github.com/philipcristiano/timeline/releases/tag/v0.0.1) - 2024-01-18
+
+### Other
+- Update package name for crate publishing
+- Display doc titles
+- Include atlast is dockerfile
+- squash
+- squash
+- Test SQLX cache with CI
+- Write documents to Postgres
+- Collect datetime
+- Add postgres bootstrapping
+- Fetch paperless docs
+- Initial commit


### PR DESCRIPTION
## 🤖 New release
* `timeline-service`: 0.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.1](https://github.com/philipcristiano/timeline/releases/tag/v0.0.1) - 2024-01-18

### Other
- Update package name for crate publishing
- Display doc titles
- Include atlast is dockerfile
- squash
- squash
- Test SQLX cache with CI
- Write documents to Postgres
- Collect datetime
- Add postgres bootstrapping
- Fetch paperless docs
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).