### PR TITLE
chore: release v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3](https://github.com/philipcristiano/timeline/compare/v0.0.2...v0.0.3) - 2024-01-24
+
+### Other
+- Sync in the background
+
 ## [0.0.1](https://github.com/philipcristiano/timeline/releases/tag/v0.0.1) - 2024-01-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "timeline-service"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timeline-service"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "A personal timeline"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `timeline-service`: 0.0.2 -> 0.0.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.3](https://github.com/philipcristiano/timeline/compare/v0.0.2...v0.0.3) - 2024-01-24

### Other
- Sync in the background
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).