### PR TITLE
fix: Pass along tracing headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,9 +3803,9 @@ dependencies = [
 
 [[package]]
 name = "service_conventions"
-version = "0.0.17"
+version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0ed26df4f168d7ab57fba6da5287c73ceedbcedd100373dc4d934d3591d7a39"
+checksum = "4467d10e5e048101684b91ed7e08fce56561b742e60f1601bedbf55c5f2535dd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4406,6 +4406,7 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
+ "http 1.1.0",
  "maud",
  "once_cell",
  "openidconnect",

--- a/timeline-server/Cargo.toml
+++ b/timeline-server/Cargo.toml
@@ -32,7 +32,7 @@ openidconnect = "3.5.0"
 reqwest = { version = "0.12.5", features = ["rustls-tls", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-service_conventions = { version = "0.0.17", features = ["tracing", "oidc"]}
+service_conventions = { version = "0.0.18", features = ["tracing", "oidc"] }
 thiserror = "1.0.58"
 tokio = { version = "1.37.0", features = ["full", "rt"] }
 toml = "0.8.12"
@@ -48,3 +48,4 @@ declare_schema = { git = "https://github.com/philipcristiano/declare-schema.git"
 extism = "1.4.1"
 axum-embed = "0.1.0"
 rust-embed = "8.4.0"
+http = "1.1.0"

--- a/timeline-server/src/integrations/paperless_ngx.rs
+++ b/timeline-server/src/integrations/paperless_ngx.rs
@@ -2,6 +2,7 @@ use crate::integration::{IntegrationT, ItemT};
 
 use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use serde::Deserialize;
+use std::collections::HashMap;
 
 use async_stream::try_stream;
 use chrono::prelude::*;
@@ -106,11 +107,13 @@ async fn request(
     url: &String,
     token: &String,
 ) -> anyhow::Result<reqwest::Response> {
+    let tracing_headers = service_conventions::tracing_http::get_tracing_headers();
     Ok(client
         .get(url)
         .header(AUTHORIZATION, format!("Token {token}"))
         .header(CONTENT_TYPE, "application/json")
         .header(ACCEPT, "application/json")
+        .headers(tracing_headers)
         .send()
         .await?)
 }


### PR DESCRIPTION
Pass along tracing headers for paperless reqwests 

So the source from `timeline` can flow through to backends