### PR TITLE
chore: Refactor DATABASE_URL config

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       flakes-from-devshell: true
       script: |
-        unset DATABASE_URL
+        export SQLX_OFFLINE=true
         cargo build
 
   database:
@@ -65,6 +65,6 @@ jobs:
         with:
           flakes-from-devshell: true
           script: |
-            unset DATABASE_URL
+            export SQLX_OFFLINE=true
             cargo build --bin timeline-migrate
             cargo run --bin timeline-migrate -- --config-file="config.github-actions.toml" migrate

--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           flakes-from-devshell: true
           script: |
-            unset DATABASE_URL
+            export SQLX_OFFLINE=true
             cargo build --bin timeline-migrate
             cargo run --bin timeline-migrate -- --config-file="config.github-actions.toml" migrate
 
@@ -59,16 +59,6 @@ jobs:
           curl -sL https://github.com/tailwindlabs/tailwindcss/releases/download/v3.4.1/tailwindcss-linux-x64 -o tailwindcss
           chmod +x tailwindcss
           mv tailwindcss /usr/local/bin
-
-  # release-please-manifest:
-  #   needs: [flake, rust, database]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: googleapis/release-please-action@v4
-  #       with:
-  #         token: ${{ secrets.REPO_TOKEN }}
-  #         config-file: release-please-config.json
-  #         manifest-file: .release-please-manifest.json
 
   release-please:
     needs: [flake, rust, database]
@@ -86,4 +76,5 @@ jobs:
       flakes-from-devshell: true
       script: |
         unset DATABASE_URL
+        export SQLX_OFFLINE=true
         cargo build

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,2 @@
+[env]
+DATABASE_URL = "postgres://timeline@localhost/timeline?sslmode=disable"

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,8 @@
             ];
             shellHook = ''
               export PGDATA=$PWD/pgdata
-              export DATABASE_URL="postgres://timeline@localhost/timeline?sslmode=disable"
+              export PGDATABASE=et
+              export PGUSER=et
             '';
           };
         }


### PR DESCRIPTION
My other projects use DATABASE_URL set in flake.nix. If I load my editor and switch projects then the other-project DATABASE_URL is set for this project.

Move configurations around so that SQLX knows where to pick up values without having shell envs infect other projects