### PR TITLE
chore: Fix envvars

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="postgres://timeline@localhost/timeline?sslmode=disable"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /usr/src/app
 
 COPY . .
 COPY --from=d3fk/tailwindcss:stable /tailwindcss /usr/local/bin/tailwindcss
+ENV SQLX_OFFLINE=true
 RUN mkdir -p /usr/src/output
 RUN cargo build --release --target-dir=/usr/src/output
 

--- a/config.toml
+++ b/config.toml
@@ -1,2 +1,0 @@
-[env]
-DATABASE_URL = "postgres://timeline@localhost/timeline?sslmode=disable"


### PR DESCRIPTION
config.toml is read for unstable cargo, but not stable.

SQLX will check a .env file if it exists and can read DATABASE_URL from there