### PR TITLE
chore: remove openssl

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,6 @@
                 rust-bin.stable.latest.default
                 rust-analyzer
                 pkgs.postgresql_16
-                pkgs.openssl # native-tls is included in cargo, needs work to remove
                 pkgs.foreman
                 pkgs.tailwindcss
             ] ++

--- a/timeline-server/Cargo.toml
+++ b/timeline-server/Cargo.toml
@@ -29,7 +29,7 @@ maud = { version="0.26.0", features = ["axum"] }
 
 once_cell = "1.19.0"
 openidconnect = "3.5.0"
-reqwest = { version = "0.12.5", features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12.5", features = ["rustls-tls", "json"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 service_conventions = { version = "0.0.23", features = ["tracing", "oidc"] }


### PR DESCRIPTION
It was breaking builds and isn't explicitly used